### PR TITLE
Allow using a UUID-based URN as the ID in the device's TD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,11 @@ embassy-sync = "0.6.0"
 wot-td = { version = "0.6.2", default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0.133", default-features = false, features = ["alloc"] }
 uuid = { version = "1.11.0", default-features = false }
+const-random = "0.1.15"
+
+[patch.crates-io]
+# TODO: Remove this override once https://github.com/tkaitchuck/constrandom/issues/36 has been resolved
+const-random-macro = { git = 'https://github.com/tkaitchuck/constrandom.git', rev = "4f71cb510e77eb6a26f8c7296c17811d0416fd41"}
 
 [profile.dev]
 # Rust debug is too slow.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,10 @@ const-random = "0.1.15"
 # TODO: Remove this override once https://github.com/tkaitchuck/constrandom/issues/36 has been resolved
 const-random-macro = { git = 'https://github.com/tkaitchuck/constrandom.git', rev = "4f71cb510e77eb6a26f8c7296c17811d0416fd41"}
 
+[features]
+default = ["uuid-id"]
+uuid-id = []
+
 [profile.dev]
 # Rust debug is too slow.
 # For debug builds always builds with some optimization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ picoserve = { version = "0.12.2", features = ["embassy", "alloc"] }
 embassy-sync = "0.6.0"
 wot-td = { version = "0.6.2", default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0.133", default-features = false, features = ["alloc"] }
+uuid = { version = "1.11.0", default-features = false }
 
 [profile.dev]
 # Rust debug is too slow.


### PR DESCRIPTION
At the moment, the device does not use a UUID as the `id` in its Thing Description but the device ID. As a potential improvement, this PR lets the application generate a UUID-based URN instead via the `nuuid` crate, which is probably a slightly better practice (although the device ID is probably also unique already). As this causes slightly more overhead, I am wondering whether this change should be hidden via a feature flag, with the old approach as a fallback.