### PR TITLE
feat: add appropriate content types to picoserve resources

### DIFF
--- a/src/bin/thermometer.rs
+++ b/src/bin/thermometer.rs
@@ -240,7 +240,9 @@ async fn main(spawner: Spawner) {
         picoserve::Router::new()
             .route(
                 "/.well-known/wot",
-                get(|State(state): State<AppState>| async move { state.td }),
+                get(|State(state): State<AppState>| async move {
+                    Response::ok(state.td).with_header("Content-Type", "application/td+json")
+                }),
             )
             .route(
                 "/properties/temperature",
@@ -254,13 +256,14 @@ async fn main(spawner: Spawner) {
                     if let Ok(temperature) = temperature {
                         let body = format!("{}", temperature.as_degrees_celsius());
 
-                        return Response::ok(body);
+                        return Response::ok(body).with_header("Content-Type", "application/json");
                     }
 
                     Response::new(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "Failed to read temperature value.".into(),
                     )
+                    .with_header("Content-Type", "text/plain")
                 }),
             )
             .route(
@@ -271,13 +274,14 @@ async fn main(spawner: Spawner) {
                     if let Ok(humidity) = humidity {
                         let body = format!("{}", humidity.as_percent());
 
-                        return Response::ok(body);
+                        return Response::ok(body).with_header("Content-Type", "application/json");
                     }
 
                     Response::new(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "Failed to read humidity value.".into(),
                     )
+                    .with_header("Content-Type", "text/plain")
                 }),
             )
     }


### PR DESCRIPTION
I've noticed that, currently, our implementation is not adding the appropriate content type headers to the responses it sends. This PR fixes the issue.

Unfortunately, adding `with_header` to one response that is being returned apparently changes the return type of a closure, so now every response needs to have a `HeadersIter` attached to it, which is why I added the content type `text/plain` to the error responses as well. Maybe there is a way to omit the additional headers here, but if not adding the content type to error responses probably also does not hurt.