### PR TITLE
Avoid depending on an unreleased const_random

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,6 @@ smart-leds = { version = "0.4.0", features = ["serde"] }
 serde = { version = "1.0.215", default-features = false, features = ["alloc"] }
 portable-atomic = { version = "1.10.0", default-features = false }
 
-[patch.crates-io]
-# TODO: Remove this override once https://github.com/tkaitchuck/constrandom/issues/36 has been resolved
-const-random-macro = { git = 'https://github.com/tkaitchuck/constrandom.git', rev = "4f71cb510e77eb6a26f8c7296c17811d0416fd41"}
 
 [features]
 default = ["uuid-id"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,25 @@ macro_rules! mk_static {
 pub const SSID: &str = env!("SSID");
 pub const PASSWORD: &str = env!("PASSWORD");
 
-const UUID_SEED: [u8; 16] = const_random::const_random!([u8; 16]);
+// TODO: Remove this horrible workaround once https://github.com/tkaitchuck/constrandom/issues/36 has been resolved
+const UUID_SEED: [u8; 16] = [
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+    const_random::const_random!(u8),
+];
 
 /// Produce an urn that can be used as id
 pub fn get_urn_or_uuid(stack: Stack) -> String {


### PR DESCRIPTION
Since https://github.com/tkaitchuck/constrandom/issues/36 does not seem to see a fix soon ... Once there is a maintained fork of it we can switch but meanwhile this workaround is potentially nicer.