### PR TITLE
Apply mDNS fixes

### DIFF
--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -41,7 +41,7 @@ pub async fn mdns_task(stack: Stack<'static>, rng: Rng, name: &'static str) {
 
     let mut socket = io::bind(
         &u,
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), PORT),
+        SocketAddr::new(IpAddr::V4(ipv4), PORT),
         Some(stack.config_v4().unwrap().address.address()),
         None,
     )


### PR DESCRIPTION
Testing out the mDNS implementation, I struggled a bit to get it work, both regarding the resolution of `.local` URIs and service discovery. I think the first aspect is fixed by the first commit in this PR, while the second aspect requires the addition of a handler for PTR queries if I am not mistaken (which I will try to deal with later today).