### PR TITLE
fix: use stack IPv4 address for mDNS IPv4 interface

### DIFF
--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -86,7 +86,7 @@ pub async fn mdns_task(stack: Stack<'static>, rng: Rng, name: &'static str) {
     let signal = Signal::new();
 
     let mdns = io::Mdns::<NoopRawMutex, _, _, _, _>::new(
-        Some(Ipv4Addr::UNSPECIFIED),
+        Some(ipv4),
         None,
         recv,
         send,


### PR DESCRIPTION
As a follow-up to #18, this PR actually seems to resolve the remaining issue related to DNS-SD using mDNS. At least locally, with the simple change from this PR, I am able to obtain the TD of the device using dart_wot :)