### PR TITLE
Mention mDNS and button demo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ This demo exposes the **WS2812 LED** as a light source.
 $ cargo run --bin light
 ```
 
+### Button
+This demo exposes an integrated button via Server-Sent Events (SSE).
+
+- [x] http version based on `esp-hal` and `picoserve`
+- [x] mDNS support based on `edge-mdns`
+
+```
+$ cargo run --bin button
+```
+
 <!-- Links -->
 [license apache]: LICENSES/Apache-2.0.txt
 [license mit]: LICENSES/MIT.txt

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All the demos target the [esp-rust-board](https://github.com/esp-rs/esp-rust-boa
 This demo exposes the [shtc3](https://www.sensirion.com/shtc3/) sensor as a connected thermometer.
 
 - [x] http version based on `esp-hal` and `picoserve`
-- [ ] mDNS support based on `edge-mdns`
+- [x] mDNS support based on `edge-mdns`
 
 ```
 $ cargo run --bin thermometer
@@ -35,7 +35,7 @@ $ cargo run --bin thermometer
 This demo exposes the **WS2812 LED** as a light source.
 
 - [x] http version based on `esp-hal` and `picoserve`
-- [ ] mDNS support based on `edge-mdns`
+- [x] mDNS support based on `edge-mdns`
 
 ```
 $ cargo run --bin light


### PR DESCRIPTION
I noticed that the README file was not completely up to date anymore. This PR updates it by mentioning the now added mDNS support and the button demo.