### PR TITLE
reduced code duplication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,11 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
 ] }
 embassy-executor = { version = "0.7.0",  features = ["nightly"] }
 embassy-time     = { version = "0.4.0",  features = ["generic-queue-8"] }
+embassy-futures = "0.1.1"
+embassy-sync = "0.6.2"
 esp-hal-embassy  = { version = "0.6.0",  features = ["esp32c3"] }
 static_cell      = { version = "2.1.0",  features = ["nightly"] }
 picoserve = { version = "0.13.3", features = ["embassy", "alloc"] }
-embassy-sync = "0.6.2"
 wot-td = { version = "0.6.2", default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0.133", default-features = false, features = ["alloc"] }
 uuid = { version = "1.11.0", default-features = false }
@@ -73,3 +74,6 @@ incremental = false
 lto = 'fat'
 opt-level = 's'
 overflow-checks = false
+
+[lints.clippy]
+pedantic = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,3 @@ incremental = false
 lto = 'fat'
 opt-level = 's'
 overflow-checks = false
-
-[lints.clippy]
-pedantic = "deny"

--- a/src/bin/button.rs
+++ b/src/bin/button.rs
@@ -1,39 +1,35 @@
 #![no_std]
 #![no_main]
-#![feature(type_alias_impl_trait)]
 #![feature(impl_trait_in_assoc_type)]
+#![feature(impl_trait_in_bindings)]
+#![feature(never_type)]
 
 extern crate alloc;
 
 use portable_atomic::AtomicBool;
 
-use alloc::{
-    format,
-    string::{String, ToString},
-};
+use alloc::string::{String, ToString};
 use embassy_executor::Spawner;
-use embassy_net::{Stack, StackResources};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, watch::Watch};
-use embassy_time::{Duration, Timer};
 use esp_alloc as _;
 use esp_backtrace as _;
-use esp_hal::{
-    clock::CpuClock,
-    gpio::{Input, Pull},
-    rng::Rng,
-    timer::timg::TimerGroup,
-};
+use esp_hal::gpio::{Input, Pull};
 use esp_println::println;
-use esp_wifi::{init, wifi::WifiStaDevice, EspWifiController};
 use picoserve::{
     extract::State,
     response::{self, Redirect, Response},
     routing::get,
-    AppRouter, AppWithStateBuilder,
+    AppWithStateBuilder,
 };
-use wot_td::{builder::*, Thing};
+use wot_td::{
+    builder::{
+        BuildableHumanReadableInfo, BuildableInteractionAffordance, ReadableWriteableDataSchema,
+        SpecializableDataSchema,
+    },
+    Thing,
+};
 
-use wot_esp_hal_demo::{mdns::*, *};
+use wot_esp_hal_demo::{mk_static, to_json_response, EspThing as _};
 
 #[derive(Clone, Copy)]
 struct AppState {
@@ -41,7 +37,65 @@ struct AppState {
     td: &'static str,
 }
 
+impl wot_esp_hal_demo::EspThingState for AppState {
+    fn new(
+        spawner: embassy_executor::Spawner,
+        td: String,
+        thing_peripherals: wot_esp_hal_demo::ThingPeripherals,
+    ) -> &'static Self {
+        let app_state = mk_static!(
+            AppState,
+            AppState {
+                on: mk_static!(AtomicBool, AtomicBool::new(false)),
+                td: mk_static!(String, td),
+            }
+        );
+
+        let btn = Input::new(thing_peripherals.GPIO9, Pull::Up);
+        spawner.spawn(update_task(app_state, btn)).ok();
+
+        app_state
+    }
+}
+
+#[derive(Default)]
 struct AppProps;
+
+impl wot_esp_hal_demo::EspThing<AppProps> for AppProps {
+    const NAME: &'static str = "button";
+
+    fn build_td(name: &str, base_uri: String, id: String) -> Thing {
+        Thing::builder(name)
+            .finish_extend()
+            .id(id)
+            .base(base_uri)
+            .description("Example Thing exposing a toggle button")
+            .security(|builder| builder.no_sec().required().with_key("nosec_sc"))
+            .property("on", |p| {
+                p.finish_extend_data_schema()
+                    .attype("OnOffProperty")
+                    .title("On/Off")
+                    .description("On if the property is true, off otherwise")
+                    .form(|f| {
+                        f.href("/properties/on")
+                            .op(wot_td::thing::FormOperation::ReadProperty)
+                    })
+                    .bool()
+                    .read_only()
+            })
+            .event("on", |b| {
+                b.data(|b| b.finish_extend().bool()).form(|form_builder| {
+                    form_builder
+                        .href("/events/on")
+                        .op(wot_td::thing::FormOperation::SubscribeEvent)
+                        .op(wot_td::thing::FormOperation::UnsubscribeEvent)
+                        .subprotocol("sse")
+                })
+            })
+            .build()
+            .unwrap()
+    }
+}
 
 impl AppWithStateBuilder for AppProps {
     type State = AppState;
@@ -70,37 +124,6 @@ impl AppWithStateBuilder for AppProps {
     }
 }
 
-const WEB_TASK_POOL_SIZE: usize = 8;
-// One for each http worker, 2 for mdns, 2 for internal esp-wifi use
-const STACK_POOL: usize = WEB_TASK_POOL_SIZE + MDNS_STACK_SIZE + 2;
-
-#[embassy_executor::task(pool_size = WEB_TASK_POOL_SIZE)]
-async fn web_task(
-    id: usize,
-    stack: Stack<'static>,
-    app: &'static AppRouter<AppProps>,
-    config: &'static picoserve::Config<Duration>,
-    state: &'static AppState,
-) -> ! {
-    let port = 80;
-    let mut tcp_rx_buffer = [0; 1024];
-    let mut tcp_tx_buffer = [0; 1024];
-    let mut http_buffer = [0; 2048];
-
-    picoserve::listen_and_serve_with_state(
-        id,
-        app,
-        config,
-        stack,
-        port,
-        &mut tcp_rx_buffer,
-        &mut tcp_tx_buffer,
-        &mut http_buffer,
-        state,
-    )
-    .await
-}
-
 static WATCH: Watch<CriticalSectionRawMutex, bool, 2> = Watch::new();
 
 #[embassy_executor::task]
@@ -120,7 +143,7 @@ async fn update_task(state: &'static AppState, mut btn: Input<'static>) -> ! {
 
 struct Events<'a>(embassy_sync::watch::Receiver<'a, CriticalSectionRawMutex, bool, 2>);
 
-impl<'a> response::sse::EventSource for Events<'a> {
+impl response::sse::EventSource for Events<'_> {
     async fn write_events<W: picoserve::io::Write>(
         mut self,
         mut writer: response::sse::EventWriter<W>,
@@ -135,7 +158,7 @@ impl<'a> response::sse::EventSource for Events<'a> {
                 Ok(value) => {
                     writer
                         .write_event("value_changed", value.to_string().as_str())
-                        .await?
+                        .await?;
                 }
                 Err(_) => writer.write_keepalive().await?,
             }
@@ -145,131 +168,5 @@ impl<'a> response::sse::EventSource for Events<'a> {
 
 #[esp_hal_embassy::main]
 async fn main(spawner: Spawner) {
-    esp_println::logger::init_logger_from_env();
-    let peripherals = esp_hal::init({
-        let mut config = esp_hal::Config::default();
-        config.cpu_clock = CpuClock::max();
-        config
-    });
-
-    let rng = Rng::new(peripherals.RNG);
-
-    esp_alloc::heap_allocator!(72 * 1024);
-
-    let timg0 = TimerGroup::new(peripherals.TIMG0);
-
-    let init = &*mk_static!(
-        EspWifiController<'static>,
-        init(timg0.timer0, rng, peripherals.RADIO_CLK,).unwrap()
-    );
-
-    let wifi = peripherals.WIFI;
-    let (wifi_interface, controller) =
-        esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
-
-    use esp_hal::timer::systimer::SystemTimer;
-    let systimer = SystemTimer::new(peripherals.SYSTIMER);
-    esp_hal_embassy::init(systimer.alarm0);
-
-    let config = embassy_net::Config::dhcpv4(Default::default());
-
-    let seed = 1234; // very random, very secure seed
-
-    // Init network stack
-    let (stack, runner) = embassy_net::new(
-        wifi_interface,
-        config,
-        mk_static!(
-            StackResources<STACK_POOL>,
-            StackResources::<STACK_POOL>::new()
-        ),
-        seed,
-    );
-
-    spawner.spawn(connection(controller)).ok();
-    spawner.spawn(net_task(runner)).ok();
-
-    loop {
-        if stack.is_link_up() {
-            break;
-        }
-        Timer::after(Duration::from_millis(500)).await;
-    }
-
-    let base_uri;
-    println!("Waiting to get IP address...");
-    loop {
-        if let Some(config) = stack.config_v4() {
-            println!("Got IP: {}", config.address);
-            base_uri = format!("http://{}", config.address.address());
-            break;
-        }
-        Timer::after(Duration::from_millis(500)).await;
-    }
-
-    let btn = Input::new(peripherals.GPIO9, Pull::Up);
-
-    let id = get_urn_or_uuid(stack);
-
-    let name = "button";
-
-    let td = Thing::builder(name)
-        .finish_extend()
-        .id(id)
-        .base(base_uri)
-        .description("Example Thing exposing a toggle button")
-        .security(|builder| builder.no_sec().required().with_key("nosec_sc"))
-        .property("on", |p| {
-            p.finish_extend_data_schema()
-                .attype("OnOffProperty")
-                .title("On/Off")
-                .description("On if the property is true, off otherwise")
-                .form(|f| {
-                    f.href("/properties/on")
-                        .op(wot_td::thing::FormOperation::ReadProperty)
-                })
-                .bool()
-                .read_only()
-        })
-        .event("on", |b| {
-            b.data(|b| b.finish_extend().bool()).form(|form_builder| {
-                form_builder
-                    .href("/events/on")
-                    .op(wot_td::thing::FormOperation::SubscribeEvent)
-                    .op(wot_td::thing::FormOperation::UnsubscribeEvent)
-                    .subprotocol("sse")
-            })
-        })
-        .build()
-        .unwrap();
-
-    let td = serde_json::to_string(&td).unwrap();
-
-    let app_state = mk_static!(
-        AppState,
-        AppState {
-            on: mk_static!(AtomicBool, AtomicBool::new(false)),
-            td: mk_static!(String, td),
-        }
-    );
-
-    spawner.spawn(update_task(app_state, btn)).ok();
-
-    let app = mk_static!(AppRouter<AppProps>, AppProps.build_app());
-
-    let config = mk_static!(
-        picoserve::Config::<Duration>,
-        picoserve::Config::new(picoserve::Timeouts {
-            start_read_request: Some(Duration::from_secs(5)),
-            read_request: Some(Duration::from_secs(1)),
-            write: Some(Duration::from_secs(1)),
-        })
-        .keep_connection_alive()
-    );
-
-    spawner.spawn(mdns_task(stack, rng, name)).ok();
-
-    for id in 0..WEB_TASK_POOL_SIZE {
-        spawner.must_spawn(web_task(id, stack, app, config, app_state));
-    }
+    AppProps::run(spawner).await;
 }

--- a/src/bin/thermometer.rs
+++ b/src/bin/thermometer.rs
@@ -11,31 +11,31 @@ use alloc::{
 };
 
 use embassy_executor::Spawner;
-use embassy_net::{Stack, StackResources};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex, watch::Watch};
 use embassy_time::{Duration, Timer};
 use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::{
-    clock::CpuClock,
     i2c::master::{Config, I2c},
-    rng::Rng,
     time::RateExtU32,
-    timer::timg::TimerGroup,
     Blocking,
 };
-use esp_println::println;
-use esp_wifi::{init, wifi::WifiStaDevice, EspWifiController};
 use picoserve::{
     extract::State,
     response::{self, Redirect, Response, StatusCode},
     routing::get,
-    AppRouter, AppWithStateBuilder,
+    AppWithStateBuilder,
 };
 use shtcx::{self, sensor_class::Sht2Gen, shtc3, PowerMode, ShtCx};
-use wot_td::{builder::*, Thing};
+use wot_td::{
+    builder::{
+        BuildableDataSchema, BuildableHumanReadableInfo, BuildableInteractionAffordance,
+        ReadableWriteableDataSchema, SpecializableDataSchema,
+    },
+    Thing,
+};
 
-use wot_esp_hal_demo::{mdns::*, *};
+use wot_esp_hal_demo::{mk_static, EspThing as _};
 
 #[derive(Clone, Copy)]
 struct AppState {
@@ -69,7 +69,116 @@ impl AppState {
     }
 }
 
+impl wot_esp_hal_demo::EspThingState for AppState {
+    fn new(
+        spawner: embassy_executor::Spawner,
+        td: String,
+        peripherals: wot_esp_hal_demo::ThingPeripherals,
+    ) -> &'static Self {
+        // Initialize temperature sensor
+
+        let sda = peripherals.GPIO10;
+        let scl = peripherals.GPIO8;
+
+        let i2c = mk_static!(
+            I2c<'static, Blocking>,
+            I2c::new(
+                peripherals.I2C0,
+                Config::default().with_frequency(100.kHz())
+            )
+            .expect("Cannot access the thermometer")
+            .with_sda(sda)
+            .with_scl(scl)
+        );
+
+        let sht = mk_static!(
+            ShtCx < Sht2Gen,
+            &'static mut I2c<'static, Blocking>>,
+            shtc3(i2c)
+        );
+
+        let sensor = mk_static!(
+            Mutex<
+                CriticalSectionRawMutex,
+            &'static mut
+                ShtCx<
+                Sht2Gen,&'static mut
+                I2c<
+                'static,
+            Blocking,
+            >
+                >
+                >,
+            Mutex::<CriticalSectionRawMutex, _>::new(sht)
+        );
+
+        let app_state = mk_static!(
+            AppState,
+            AppState {
+                sensor,
+                td: mk_static!(String, td),
+            }
+        );
+
+        spawner.spawn(temperature_write_task(app_state)).ok();
+
+        app_state
+    }
+}
+
+#[derive(Default)]
 struct AppProps;
+
+impl wot_esp_hal_demo::EspThing<AppProps> for AppProps {
+    const NAME: &'static str = "shtc3";
+
+    fn build_td(name: &str, base_uri: String, id: String) -> Thing {
+        Thing::builder(name)
+            .finish_extend()
+            .id(id)
+            .base(base_uri)
+            .description("Example Thing exposing a shtc3 sensor")
+            .security(|builder| builder.no_sec().required().with_key("nosec_sc"))
+            .property("temperature", |p| {
+                p.finish_extend_data_schema()
+                    .attype("TemperatureProperty")
+                    .title("Temperature")
+                    .description("Current temperature")
+                    .form(|f| {
+                        f.href("/properties/temperature")
+                            .op(wot_td::thing::FormOperation::ReadProperty)
+                    })
+                    .number()
+                    .read_only()
+                    .unit("Celsius")
+            })
+            .property("humidity", |p| {
+                p.finish_extend_data_schema()
+                    .attype("HumidityProperty")
+                    .title("Humidity")
+                    .description("Current humidity")
+                    .form(|f| {
+                        f.href("/properties/humidity")
+                            .op(wot_td::thing::FormOperation::ReadProperty)
+                    })
+                    .number()
+                    .read_only()
+                    .unit("%")
+            })
+            .event("temperature", |b| {
+                b.data(|b| b.finish_extend().number().unit("Celsius"))
+                    .form(|form_builder| {
+                        form_builder
+                            .href("/events/temperature")
+                            .op(wot_td::thing::FormOperation::SubscribeEvent)
+                            .op(wot_td::thing::FormOperation::UnsubscribeEvent)
+                            .subprotocol("sse")
+                    })
+            })
+            .build()
+            .unwrap()
+    }
+}
 
 impl AppWithStateBuilder for AppProps {
     type State = AppState;
@@ -90,7 +199,7 @@ impl AppWithStateBuilder for AppProps {
                     let temperature = state.get_temperature().await;
 
                     if let Ok(temperature) = temperature {
-                        let body = format!("{}", temperature);
+                        let body = format!("{temperature}");
 
                         return Response::ok(body).with_header("Content-Type", "application/json");
                     }
@@ -108,7 +217,7 @@ impl AppWithStateBuilder for AppProps {
                     let humidity = state.get_humidity().await;
 
                     if let Ok(humidity) = humidity {
-                        let body = format!("{}", humidity);
+                        let body = format!("{humidity}");
 
                         return Response::ok(body).with_header("Content-Type", "application/json");
                     }
@@ -127,38 +236,8 @@ impl AppWithStateBuilder for AppProps {
     }
 }
 
-const WEB_TASK_POOL_SIZE: usize = 8;
-// One for each http worker, 2 for mdns, 2 for internal esp-wifi use
-const STACK_POOL: usize = WEB_TASK_POOL_SIZE + MDNS_STACK_SIZE + 2;
-
-#[embassy_executor::task(pool_size = WEB_TASK_POOL_SIZE)]
-async fn web_task(
-    id: usize,
-    stack: Stack<'static>,
-    app: &'static AppRouter<AppProps>,
-    config: &'static picoserve::Config<Duration>,
-    state: &'static AppState,
-) -> ! {
-    let port = 80;
-    let mut tcp_rx_buffer = [0; 1024];
-    let mut tcp_tx_buffer = [0; 1024];
-    let mut http_buffer = [0; 2048];
-
-    picoserve::listen_and_serve_with_state(
-        id,
-        app,
-        config,
-        stack,
-        port,
-        &mut tcp_rx_buffer,
-        &mut tcp_tx_buffer,
-        &mut http_buffer,
-        state,
-    )
-    .await
-}
-
 #[embassy_executor::task]
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 async fn temperature_write_task(state: &'static AppState) -> ! {
     let sender = WATCH.sender();
     let t = state.get_temperature().await.unwrap_or(-500.0);
@@ -186,7 +265,7 @@ static WATCH: Watch<CriticalSectionRawMutex, f32, 2> = Watch::new();
 
 struct Events<'a>(embassy_sync::watch::Receiver<'a, CriticalSectionRawMutex, f32, 2>);
 
-impl<'a> response::sse::EventSource for Events<'a> {
+impl response::sse::EventSource for Events<'_> {
     async fn write_events<W: picoserve::io::Write>(
         mut self,
         mut writer: response::sse::EventWriter<W>,
@@ -201,7 +280,7 @@ impl<'a> response::sse::EventSource for Events<'a> {
                 Ok(value) => {
                     writer
                         .write_event("value_changed", value.to_string().as_str())
-                        .await?
+                        .await?;
                 }
                 Err(_) => writer.write_keepalive().await?,
             }
@@ -211,181 +290,5 @@ impl<'a> response::sse::EventSource for Events<'a> {
 
 #[esp_hal_embassy::main]
 async fn main(spawner: Spawner) {
-    esp_println::logger::init_logger_from_env();
-    let peripherals = esp_hal::init({
-        let mut config = esp_hal::Config::default();
-        config.cpu_clock = CpuClock::max();
-        config
-    });
-
-    let rng = Rng::new(peripherals.RNG);
-
-    esp_alloc::heap_allocator!(72 * 1024);
-
-    let timg0 = TimerGroup::new(peripherals.TIMG0);
-
-    let init = &*mk_static!(
-        EspWifiController<'static>,
-        init(timg0.timer0, rng, peripherals.RADIO_CLK,).unwrap()
-    );
-
-    let wifi = peripherals.WIFI;
-    let (wifi_interface, controller) =
-        esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
-
-    use esp_hal::timer::systimer::SystemTimer;
-    let systimer = SystemTimer::new(peripherals.SYSTIMER);
-    esp_hal_embassy::init(systimer.alarm0);
-
-    let config = embassy_net::Config::dhcpv4(Default::default());
-
-    let seed = 1234; // very random, very secure seed
-
-    // Init network stack
-    let (stack, runner) = embassy_net::new(
-        wifi_interface,
-        config,
-        mk_static!(
-            StackResources<STACK_POOL>,
-            StackResources::<STACK_POOL>::new()
-        ),
-        seed,
-    );
-
-    spawner.spawn(connection(controller)).ok();
-    spawner.spawn(net_task(runner)).ok();
-
-    loop {
-        if stack.is_link_up() {
-            break;
-        }
-        Timer::after(Duration::from_millis(500)).await;
-    }
-
-    let base_uri;
-    println!("Waiting to get IP address...");
-    loop {
-        if let Some(config) = stack.config_v4() {
-            println!("Got IP: {}", config.address);
-            base_uri = format!("http://{}", config.address.address());
-            break;
-        }
-        Timer::after(Duration::from_millis(500)).await;
-    }
-
-    // Initialize temperature sensor
-
-    let sda = peripherals.GPIO10;
-    let scl = peripherals.GPIO8;
-
-    let i2c = mk_static!(
-        I2c<'static, Blocking>,
-        I2c::new(
-            peripherals.I2C0,
-            Config::default().with_frequency(100.kHz())
-        )
-        .expect("Cannot access the thermometer")
-        .with_sda(sda)
-        .with_scl(scl)
-    );
-
-    let sht = mk_static!(
-        ShtCx < Sht2Gen,
-        &'static mut I2c<'static, Blocking>>,
-        shtc3(i2c)
-    );
-
-    let id = get_urn_or_uuid(stack);
-
-    let name = "shtc3";
-
-    let td = Thing::builder(name)
-        .finish_extend()
-        .id(id)
-        .base(base_uri)
-        .description("Example Thing exposing a shtc3 sensor")
-        .security(|builder| builder.no_sec().required().with_key("nosec_sc"))
-        .property("temperature", |p| {
-            p.finish_extend_data_schema()
-                .attype("TemperatureProperty")
-                .title("Temperature")
-                .description("Current temperature")
-                .form(|f| {
-                    f.href("/properties/temperature")
-                        .op(wot_td::thing::FormOperation::ReadProperty)
-                })
-                .number()
-                .read_only()
-                .unit("Celsius")
-        })
-        .property("humidity", |p| {
-            p.finish_extend_data_schema()
-                .attype("HumidityProperty")
-                .title("Humidity")
-                .description("Current humidity")
-                .form(|f| {
-                    f.href("/properties/humidity")
-                        .op(wot_td::thing::FormOperation::ReadProperty)
-                })
-                .number()
-                .read_only()
-                .unit("%")
-        })
-        .event("temperature", |b| {
-            b.data(|b| b.finish_extend().number().unit("Celsius"))
-                .form(|form_builder| {
-                    form_builder
-                        .href("/events/temperature")
-                        .op(wot_td::thing::FormOperation::SubscribeEvent)
-                        .op(wot_td::thing::FormOperation::UnsubscribeEvent)
-                        .subprotocol("sse")
-                })
-        })
-        .build()
-        .unwrap();
-
-    let td = serde_json::to_string(&td).unwrap();
-
-    let sensor = mk_static!(
-            Mutex<
-                CriticalSectionRawMutex,
-                &'static mut
-                ShtCx<
-                    Sht2Gen,&'static mut
-                    I2c<
-                        'static,
-                        Blocking,
-                    >
-                >
-            >,
-        Mutex::<CriticalSectionRawMutex, _>::new(sht)
-    );
-
-    let app_state = mk_static!(
-        AppState,
-        AppState {
-            sensor,
-            td: mk_static!(String, td),
-        }
-    );
-
-    let app = mk_static!(AppRouter<AppProps>, AppProps.build_app());
-
-    let config = mk_static!(
-        picoserve::Config::<Duration>,
-        picoserve::Config::new(picoserve::Timeouts {
-            start_read_request: Some(Duration::from_secs(5)),
-            read_request: Some(Duration::from_secs(1)),
-            write: Some(Duration::from_secs(1)),
-        })
-        .keep_connection_alive()
-    );
-
-    spawner.spawn(mdns_task(stack, rng, name)).ok();
-
-    for id in 0..WEB_TASK_POOL_SIZE {
-        spawner.must_spawn(web_task(id, stack, app, config, app_state));
-    }
-
-    spawner.spawn(temperature_write_task(app_state)).ok();
+    AppProps::run(spawner).await;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![feature(type_alias_impl_trait)]
 #![feature(impl_trait_in_assoc_type)]
+#![feature(never_type)]
+#![feature(impl_trait_in_bindings)]
 
 extern crate alloc;
 
@@ -15,7 +17,10 @@ use esp_wifi::wifi::{
     ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiStaDevice,
     WifiState,
 };
-use picoserve::response::{IntoResponse, Response};
+use picoserve::{
+    response::{IntoResponse, Response},
+    AppRouter, AppWithStateBuilder,
+};
 
 pub mod mdns;
 pub mod smartled;
@@ -53,6 +58,7 @@ const UUID_SEED: [u8; 16] = [
 ];
 
 /// Produce an urn that can be used as id
+#[must_use]
 pub fn get_urn_or_uuid(stack: Stack) -> String {
     if cfg!(feature = "uuid-id") {
         let uuid = uuid::Builder::from_random_bytes(UUID_SEED).into_uuid();
@@ -64,6 +70,8 @@ pub fn get_urn_or_uuid(stack: Stack) -> String {
     }
 }
 
+/// # Panics
+#[must_use]
 pub fn to_json_response<T: serde::Serialize>(data: &T) -> impl IntoResponse {
     let body = serde_json::to_string(data).unwrap();
     Response::ok(body).with_header("Content-Type", "application/json")
@@ -77,7 +85,7 @@ pub async fn connection(mut controller: WifiController<'static>) {
         if esp_wifi::wifi::wifi_state() == WifiState::StaConnected {
             // wait until we're no longer connected
             controller.wait_for_event(WifiEvent::StaDisconnected).await;
-            Timer::after(Duration::from_millis(5000)).await
+            Timer::after(Duration::from_millis(5000)).await;
         }
         if !matches!(controller.is_started(), Ok(true)) {
             let client_config = Configuration::Client(ClientConfiguration {
@@ -93,10 +101,10 @@ pub async fn connection(mut controller: WifiController<'static>) {
         println!("About to connect...");
 
         match controller.connect_async().await {
-            Ok(_) => println!("Wifi connected!"),
+            Ok(()) => println!("Wifi connected!"),
             Err(e) => {
                 println!("Failed to connect to wifi: {e:?}");
-                Timer::after(Duration::from_millis(5000)).await
+                Timer::after(Duration::from_millis(5000)).await;
             }
         }
     }
@@ -104,5 +112,163 @@ pub async fn connection(mut controller: WifiController<'static>) {
 
 #[embassy_executor::task]
 pub async fn net_task(mut runner: Runner<'static, WifiDevice<'static, WifiStaDevice>>) {
-    runner.run().await
+    runner.run().await;
+}
+
+#[allow(clippy::similar_names)]
+pub async fn web_task<Props: AppWithStateBuilder>(
+    id: usize,
+    stack: Stack<'static>,
+    app: &'static AppRouter<Props>,
+    config: &'static picoserve::Config<Duration>,
+    state: &'static Props::State,
+) -> ! {
+    let port = 80;
+    let mut tcp_rx_buffer = [0; 1024];
+    let mut tcp_tx_buffer = [0; 1024];
+    let mut http_buffer = [0; 2048];
+
+    picoserve::listen_and_serve_with_state(
+        id,
+        app,
+        config,
+        stack,
+        port,
+        &mut tcp_rx_buffer,
+        &mut tcp_tx_buffer,
+        &mut http_buffer,
+        state,
+    )
+    .await
+}
+
+#[allow(non_snake_case)]
+pub struct ThingPeripherals {
+    pub I2C0: esp_hal::peripherals::I2C0,
+    pub GPIO2: esp_hal::gpio::GpioPin<2>,
+    pub GPIO8: esp_hal::gpio::GpioPin<8>,
+    pub GPIO9: esp_hal::gpio::GpioPin<9>,
+    pub GPIO10: esp_hal::gpio::GpioPin<10>,
+    pub RMT: esp_hal::peripherals::RMT,
+}
+
+pub trait EspThingState {
+    fn new(
+        spawner: embassy_executor::Spawner,
+        td: String,
+        thing_peripherals: ThingPeripherals,
+    ) -> &'static Self;
+}
+
+pub trait EspThing<Props>
+where
+    Props: AppWithStateBuilder + Default + 'static,
+    Props::State: EspThingState + 'static,
+{
+    const NAME: &'static str;
+
+    fn build_td(name: &str, base_uri: String, id: String) -> wot_td::Thing;
+
+    #[allow(async_fn_in_trait, clippy::must_use_candidate)]
+    async fn run(spawner: embassy_executor::Spawner) {
+        esp_println::logger::init_logger_from_env();
+        let peripherals = esp_hal::init({
+            let mut config = esp_hal::Config::default();
+            config.cpu_clock = esp_hal::clock::CpuClock::max();
+            config
+        });
+
+        let rng = esp_hal::rng::Rng::new(peripherals.RNG);
+
+        esp_alloc::heap_allocator!(144 * 1024);
+
+        let timg0 = esp_hal::timer::timg::TimerGroup::new(peripherals.TIMG0);
+
+        let init = &*mk_static!(
+            esp_wifi::EspWifiController<'static>,
+            esp_wifi::init(timg0.timer0, rng, peripherals.RADIO_CLK,).unwrap()
+        );
+
+        let wifi = peripherals.WIFI;
+        let (wifi_interface, controller) =
+            esp_wifi::wifi::new_with_mode(init, wifi, WifiStaDevice).unwrap();
+
+        let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER);
+        esp_hal_embassy::init(systimer.alarm0);
+
+        let config = embassy_net::Config::dhcpv4(embassy_net::DhcpConfig::default());
+
+        let seed = 1234; // very random, very secure seed
+
+        // Init network stack
+        let (stack, runner) = embassy_net::new(
+            wifi_interface,
+            config,
+            alloc::boxed::Box::leak(alloc::boxed::Box::new(embassy_net::StackResources::<
+                { 8 * mdns::MDNS_STACK_SIZE + 2 },
+            >::new())),
+            seed,
+        );
+
+        spawner.spawn(connection(controller)).ok();
+        spawner.spawn(net_task(runner)).ok();
+
+        loop {
+            if stack.is_link_up() {
+                break;
+            }
+            Timer::after(Duration::from_millis(500)).await;
+        }
+
+        let base_uri;
+        println!("Waiting to get IP address...");
+        loop {
+            if let Some(config) = stack.config_v4() {
+                println!("Got IP: {}", config.address);
+                base_uri = format!("http://{}", config.address.address());
+                break;
+            }
+            Timer::after(Duration::from_millis(500)).await;
+        }
+
+        let id = get_urn_or_uuid(stack);
+
+        let name = Self::NAME;
+
+        let td = Self::build_td(Self::NAME, base_uri, id);
+
+        let td = serde_json::to_string(&td).unwrap();
+
+        let thing_peripherals = ThingPeripherals {
+            I2C0: peripherals.I2C0,
+            GPIO2: peripherals.GPIO2,
+            GPIO8: peripherals.GPIO8,
+            GPIO9: peripherals.GPIO9,
+            GPIO10: peripherals.GPIO10,
+            RMT: peripherals.RMT,
+        };
+
+        let app_state = Props::State::new(spawner, td, thing_peripherals);
+
+        let app = alloc::boxed::Box::leak(alloc::boxed::Box::new(Props::default().build_app()));
+
+        let config = mk_static!(
+            picoserve::Config::<Duration>,
+            picoserve::Config::new(picoserve::Timeouts {
+                start_read_request: Some(Duration::from_secs(5)),
+                read_request: Some(Duration::from_secs(1)),
+                write: Some(Duration::from_secs(1)),
+            })
+            .keep_connection_alive()
+        );
+
+        spawner.spawn(mdns::mdns_task(stack, rng, name)).ok();
+
+        let web_tasks: [core::pin::Pin<alloc::boxed::Box<impl core::future::Future<Output = !>>>;
+            8] = core::array::from_fn(|id| {
+            alloc::boxed::Box::pin(web_task::<Props>(id, stack, app, config, app_state))
+        });
+
+        embassy_futures::join::join_array(web_tasks).await;
+    }
 }

--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -27,7 +27,7 @@ pub const MDNS_STACK_SIZE: usize = 2;
 
 #[embassy_executor::task]
 pub async fn mdns_task(stack: Stack<'static>, rng: Rng, name: &'static str) {
-    RNG.lock(|c| _ = c.set(rng.clone()));
+    RNG.lock(|c| _ = c.set(rng));
 
     let ipv4 = stack.config_v4().unwrap().address.address();
     let (recv_buf, send_buf) = (
@@ -102,5 +102,5 @@ pub async fn mdns_task(stack: Stack<'static>, rng: Rng, name: &'static str) {
         &host, &service,
     )))
     .await
-    .unwrap()
+    .unwrap();
 }

--- a/src/smartled.rs
+++ b/src/smartled.rs
@@ -88,6 +88,8 @@ where
     TX: TxChannel,
 {
     /// Create a new adapter object that drives the pin using the RMT channel.
+    /// # Panics
+    #[allow(clippy::cast_possible_truncation)]
     pub fn new<C, O>(
         channel: C,
         pin: impl Peripheral<P = O> + 'd,


### PR DESCRIPTION
I think this approach of mine is a bit excessive: it's up to you whether you want to ignore the PR or reduce the refactoring.

The idea is to use embassy futures join to have generic tasks (currently not possible to have them directly using embassy executor), use Box::leak to have static lifetime and then "templetize" the code to avoid duplication.